### PR TITLE
learn full faulty list from join sync

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,11 @@
+# 1.0.0
+
+* Removed farmhash and msgpack (default build issues)
+
+# 1.0.1
+
+* Merged upstream join-sync includes faulty-list 
+
+# 1.0.2 25-09-2016
+
+* Used join-sync's faulty-list to repopulate member's faulty-list thus preserving it indefinitely through the cluster.

--- a/lib/membership.js
+++ b/lib/membership.js
@@ -218,11 +218,22 @@ Membership.prototype.updateFaulty = function updateFaulty(data) {
         delete this.hostToMember[data.host];
         delete this.hostToIterable[data.host];
         this.emit(Membership.EventType.Change, data);
-
         this.emit(Membership.EventType.Update, data);
-    } else {
-        this.emit(Membership.EventType.Drop, data);
+        return;
     }
+
+    if (!this.hostToMember[data.host]) {
+        if (this.hostToFaulty[data.host] &&
+            data.incarnation < this.hostToFaulty[data.host].incarnation) {
+            this.emit(Membership.EventType.Drop, data);
+            return;
+        }
+        this.hostToFaulty[data.host] = new Member(data);
+        this.emit(Membership.EventType.Drop, data);
+        return;
+    }
+
+    this.emit(Membership.EventType.Drop, data);
 };
 
 Membership.prototype.next = function next() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happn-swim",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Gossip protocol based on SWIM",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
To resume incarnations in all possible cases the faulty list is preserved indefinitely through the cluster.

This solves the problem of cycling a reboot/upgrade through the cluster creating a window where newly-booted members are not reported as rejoined at not-yet-rebooted members (which have the old incarnation) because the members-to-join list have already been rebooted and thus lost the faulty list with the old incarnations, so not providing the old incarnations needed by the newly connecting members to resume from.
