### PR TITLE
Made each member the sole authority on it's metadata

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,3 +9,7 @@
 # 1.0.2 25-09-2016
 
 * Used join-sync's faulty-list to repopulate member's faulty-list thus preserving it indefinitely through the cluster.
+
+# 1.0.3 26-09-2016
+
+* Made each member the sole authority on it's metadata. 

--- a/lib/member.js
+++ b/lib/member.js
@@ -24,9 +24,9 @@ Member.prototype.incarnate = function incarnate(data, force) {
     }
 
     if (data.incarnation > this.incarnation) {
-        if (this.incarnation === 0) {
-            this.meta = data.meta;
-        }
+        // if (this.incarnation === 0) {
+        //     this.meta = data.meta;
+        // }
         this.incarnation = data.incarnation + 1;
         return true;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happn-swim",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Gossip protocol based on SWIM",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The join-time failed-list was overwriting the resuming member's meta, preventing the ability to restart with new meta.
